### PR TITLE
FIX:코드 컨벤션과 일치하게 commentAPI수정

### DIFF
--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/controller/CommentController.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/controller/CommentController.java
@@ -1,12 +1,16 @@
 package com.ssafynity_b.domain.comment.controller;
 
-import com.ssafynity_b.domain.comment.dto.CommentDto;
+import com.ssafynity_b.domain.comment.dto.GetCommentDto;
+import com.ssafynity_b.domain.comment.dto.CreateCommentDto;
+import com.ssafynity_b.domain.comment.dto.UpdateCommentDto;
 import com.ssafynity_b.domain.comment.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/comment")
@@ -17,24 +21,31 @@ public class CommentController {
 
 
     @Operation(summary = "댓글 생성")
-    @PostMapping("/{memberId}/{boardId}")
-    public ResponseEntity<CommentDto> createComment(@PathVariable Long memberId, @PathVariable Long boardId, @RequestParam String content){
-        CommentDto commentDto = commentService.createComment(memberId, boardId, content);
-        return new ResponseEntity<>(commentDto, HttpStatus.OK);
+    @PostMapping
+    public ResponseEntity<GetCommentDto> createComment(@RequestBody CreateCommentDto createCommentDto){
+        GetCommentDto getCommentDto = commentService.createComment(createCommentDto.getMemberId(), createCommentDto.getBoardId(), createCommentDto.getContent());
+        return new ResponseEntity<>(getCommentDto, HttpStatus.OK);
     }
 
     @Operation(summary = "댓글 조회")
     @GetMapping("/{commentId}")
-    public ResponseEntity<CommentDto> getComment(Long commentId){
-        CommentDto commentDto = commentService.getComment(commentId);
-        return new ResponseEntity<>(commentDto, HttpStatus.OK);
+    public ResponseEntity<GetCommentDto> getComment(@PathVariable Long commentId){
+        GetCommentDto getCommentDto = commentService.getComment(commentId);
+        return new ResponseEntity<>(getCommentDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "댓글 전체 조회")
+    @GetMapping
+    public ResponseEntity<List<GetCommentDto>> getCommentAll(){
+        List<GetCommentDto> commentDtoList = commentService.getAllComment();
+        return new ResponseEntity<>(commentDtoList,HttpStatus.OK);
     }
 
     @Operation(summary = "댓글 수정")
-    @PutMapping("/{commentId}")
-    public ResponseEntity<CommentDto> updateComment(@PathVariable Long commentId, @RequestParam String content){
-        CommentDto commentDto = commentService.updateComment(commentId, content);
-        return new ResponseEntity<>(commentDto, HttpStatus.OK);
+    @PutMapping
+    public ResponseEntity<GetCommentDto> updateComment(@RequestBody UpdateCommentDto updateCommentDto){
+        GetCommentDto getCommentDto = commentService.updateComment(updateCommentDto.getCommentId(), updateCommentDto.getContent());
+        return new ResponseEntity<>(getCommentDto, HttpStatus.OK);
     }
 
     @Operation(summary = "댓글 삭제")

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/CreateCommentDto.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/CreateCommentDto.java
@@ -1,22 +1,16 @@
 package com.ssafynity_b.domain.comment.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@Builder
-@AllArgsConstructor
 @Getter
 @Setter
-public class CommentDto {
-
+public class CreateCommentDto {
     private Long memberId;
 
     private Long boardId;
 
-    private Long commentId;
-
     private String content;
-
 }

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/GetCommentDto.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/GetCommentDto.java
@@ -1,0 +1,22 @@
+package com.ssafynity_b.domain.comment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+@Setter
+public class GetCommentDto {
+
+    private Long memberId;
+
+    private Long boardId;
+
+    private Long commentId;
+
+    private String content;
+
+}

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/UpdateCommentDto.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/dto/UpdateCommentDto.java
@@ -1,0 +1,13 @@
+package com.ssafynity_b.domain.comment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UpdateCommentDto {
+
+    private Long commentId;
+
+    private String content;
+}

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/service/CommentService.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/service/CommentService.java
@@ -1,14 +1,18 @@
 package com.ssafynity_b.domain.comment.service;
 
-import com.ssafynity_b.domain.comment.dto.CommentDto;
+import com.ssafynity_b.domain.comment.dto.GetCommentDto;
+
+import java.util.List;
 
 public interface CommentService {
 
-    public CommentDto createComment(Long memberId ,Long boardId, String content);
+    public GetCommentDto createComment(Long memberId , Long boardId, String content);
 
-    public CommentDto getComment(Long commentId);
+    public GetCommentDto getComment(Long commentId);
 
-    public CommentDto updateComment(Long commentId, String content);
+    public List<GetCommentDto> getAllComment();
+
+    public GetCommentDto updateComment(Long commentId, String content);
 
     public void deleteComment(Long commentId);
 }

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/service/impl/CommentServiceImpl.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/comment/service/impl/CommentServiceImpl.java
@@ -2,7 +2,7 @@ package com.ssafynity_b.domain.comment.service.impl;
 
 import com.ssafynity_b.domain.board.entity.Board;
 import com.ssafynity_b.domain.board.repository.BoardRepository;
-import com.ssafynity_b.domain.comment.dto.CommentDto;
+import com.ssafynity_b.domain.comment.dto.GetCommentDto;
 import com.ssafynity_b.domain.comment.entity.Comment;
 import com.ssafynity_b.domain.comment.repository.CommentRepository;
 import com.ssafynity_b.domain.comment.service.CommentService;
@@ -15,6 +15,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 public class CommentServiceImpl implements CommentService {
@@ -25,7 +27,7 @@ public class CommentServiceImpl implements CommentService {
 
     @Transactional
     @Override
-    public CommentDto createComment(Long memberId, Long boardId, String content) {
+    public GetCommentDto createComment(Long memberId, Long boardId, String content) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         Comment comment = new Comment(content);
@@ -33,7 +35,7 @@ public class CommentServiceImpl implements CommentService {
         comment.setBoard(board);
         member.getCommentList().add(comment);
         board.getCommentList().add(comment);
-        return CommentDto.builder()
+        return GetCommentDto.builder()
                 .memberId(comment.getMember().getId())
                 .boardId(comment.getBoard().getId())
                 .content(comment.getContent())
@@ -41,9 +43,9 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public CommentDto getComment(Long commentId) {
+    public GetCommentDto getComment(Long commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
-        return CommentDto.builder()
+        return GetCommentDto.builder()
                 .memberId(comment.getMember().getId())
                 .boardId(comment.getBoard().getId())
                 .commentId(comment.getId())
@@ -51,12 +53,25 @@ public class CommentServiceImpl implements CommentService {
                 .build();
     }
 
+    @Override
+    public List<GetCommentDto> getAllComment() {
+        List<Comment> commentList = commentRepository.findAll();
+        List<GetCommentDto> commentDtoList = commentList.stream().map(comment -> GetCommentDto.builder()
+                        .memberId(comment.getMember().getId())
+                        .boardId(comment.getBoard().getId())
+                        .commentId(comment.getId())
+                        .content(comment.getContent())
+                        .build())
+                .toList();
+        return commentDtoList;
+    }
+
     @Transactional
     @Override
-    public CommentDto updateComment(Long commentId, String content) {
+    public GetCommentDto updateComment(Long commentId, String content) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(CommentNotFoundException::new);
         comment.updateContent(content);
-        return CommentDto.builder()
+        return GetCommentDto.builder()
                 .boardId(comment.getBoard().getId())
                 .commentId(comment.getId())
                 .content(comment.getContent())

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/service/impl/MemberServiceImpl.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/service/impl/MemberServiceImpl.java
@@ -31,9 +31,9 @@ public class MemberServiceImpl implements MemberService {
     public Long createMember(CreateMemberDto memberDto) {
         Member member = new Member(memberDto.getEmail(), passwordEncoder.encode(memberDto.getPassword()), memberDto.getName(), memberDto.getCompany());
         Member savedMember = memberRepository.save(member);
-        MemberDocument memberDocument = new MemberDocument(savedMember.getMemberId(), savedMember.getEmail(), savedMember.getPassword(), savedMember.getName(), savedMember.getCompany());
+        MemberDocument memberDocument = new MemberDocument(savedMember.getId(), savedMember.getEmail(), savedMember.getPassword(), savedMember.getName(), savedMember.getCompany());
         documentRepository.save(memberDocument);
-        return savedMember.getMemberId();
+        return savedMember.getId();
     }
 
     @Override
@@ -67,7 +67,7 @@ public class MemberServiceImpl implements MemberService {
                 .updatePassword(memberDto.getPassword())
                 .updateName(memberDto.getName())
                 .updatdCompany(memberDto.getCompany());
-        return member.getMemberId();
+        return member.getId();
     }
 
     @Override


### PR DESCRIPTION
FIX:코드 컨벤션과 일치하게 commentAPI수정

생성 - POST localhost:8080/member - @RequestBody

단건조회 - GET localhost:8080/member/{memberId} - @PathVariable
전체조회 - GET localhost:8080/member

수정 - PUT localhost:8080/member - @RequestBody

삭제 - DELETE localhost:8080/member/{memberId} - @PathVariable

처럼 코드 컨벤션 내용대로 수정했습니다.