### PR TITLE
FEAT:[BE] jwt토큰 검증API 생성, [FE]페이지 요청마다 jwt토큰 유효성 검사 실행 로직 구현

### DIFF
--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/auth/controller/AuthController.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/auth/controller/AuthController.java
@@ -5,11 +5,12 @@ import com.ssafynity_b.domain.auth.dto.LoginResponse;
 import com.ssafynity_b.domain.auth.service.AuthService;
 import com.ssafynity_b.global.jwt.JwtConfig;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/auth")
 @RestController
@@ -21,7 +22,7 @@ public class AuthController {
         this.authService = authService;
     }
 
-    @Operation(summary = "JWT 로그인")
+    @Operation(summary = "사용자 로그인(로그인 성공 시 Jwt토큰 발급)")
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest){
         LoginResponse loginResponse = authService.authenticate(loginRequest);
@@ -29,5 +30,21 @@ public class AuthController {
             return ResponseEntity.ok(loginResponse); // 인증 성공
         }
         return ResponseEntity.status(401).body("Unauthorized"); // 인증 실패
+    }
+
+    @Operation(summary = "LocalStorage에 들어있는 Jwt토큰 유효성검사(사용자 재방문시 호출)")
+    @GetMapping("/verify")
+    public ResponseEntity<?> verifyJwtToken(){
+        // Spring Security가 자동으로 JWT를 파싱하고 유효성 검증을 수행
+        // SecurityContextHolder에 인증 정보가 있으면 유효한 토큰으로 간주
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.isAuthenticated() && !(authentication instanceof AnonymousAuthenticationToken)) {
+            System.out.println("뭐냐이거 : "+ authentication);
+            return ResponseEntity.ok("Token is valid");
+        } else {
+            System.out.println("왜터지냐??? : "+ authentication);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid token");
+        }
     }
 }

--- a/ssafynity-f/src/App.js
+++ b/ssafynity-f/src/App.js
@@ -3,12 +3,15 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import './App.css';
 import Header from './components/Header';
 import Footer from './components/Footer';
-import SignUp from "./pages/SignUp";
+import { AuthProvider } from "./components/AuthContext";
+import PrivateRoute from "./components/PrivateRoute";
+import SignUp from "./pages/Signup";
 import Login from "./pages/Login";
 import Main from "./pages/Main";
 
 function App() {
   return (
+    <AuthProvider>
     <Router>
     <div className="App">
       <Header />
@@ -16,7 +19,14 @@ function App() {
         <Routes>
             <Route path="/signup" element={<SignUp />} />
             <Route path="/login" element={<Login />} />
-            <Route path="/main" element={<Main />} />
+            <Route
+                        path="/main"
+                        element={
+                            <PrivateRoute>
+                                <Main />
+                            </PrivateRoute>
+                        }
+                    />
             <Route
               path="/"
               element={<h2>Welcome to the React App! Start here.</h2>}
@@ -26,6 +36,7 @@ function App() {
       <Footer />      
     </div>
     </Router>
+    </AuthProvider>
   );
 }
 

--- a/ssafynity-f/src/components/AuthContext.js
+++ b/ssafynity-f/src/components/AuthContext.js
@@ -1,0 +1,57 @@
+import axiosInstance from "../api/axiosInstance";
+import React, { createContext, useState, useContext, useEffect } from 'react';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+    const [isAuthenticated, setIsAuthenticated] = useState(null); // 초기값을 null로 설정
+    const [loading, setLoading] = useState(true); // 로딩 상태 추가
+
+    const login = () => setIsAuthenticated(true);
+    const logout = () => {
+        setIsAuthenticated(false);
+        localStorage.removeItem("jwtToken");
+    };
+
+    const verifyToken = async () => {
+        const token = localStorage.getItem("jwtToken");
+        if (!token) {
+            setIsAuthenticated(false);
+            setLoading(false);
+            return;
+        }
+
+        try {
+            await axiosInstance.get("/api/auth/verify", {
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            });
+            setIsAuthenticated(true); // 토큰 유효 시 로그인 상태 설정
+        } catch (error) {
+            console.error("Token verification failed", error);
+            setIsAuthenticated(false); // 토큰이 유효하지 않으면 로그아웃 상태
+            localStorage.removeItem("jwtToken"); // 유효하지 않은 토큰 삭제
+        } finally {
+            setLoading(false); // 로딩 상태 완료
+        }
+    };
+
+    useEffect(() => {
+        verifyToken();
+    }, []);
+
+    return (
+        <AuthContext.Provider value={{ isAuthenticated, login, logout, loading }}>
+            {children}
+        </AuthContext.Provider>
+    );
+};
+
+export const useAuth = () => {
+    const context = useContext(AuthContext);
+    if (!context) {
+        throw new Error("useAuth must be used within an AuthProvider");
+    }
+    return context;
+};

--- a/ssafynity-f/src/components/PrivateRoute.js
+++ b/ssafynity-f/src/components/PrivateRoute.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Navigate } from "react-router-dom";
+import { useAuth } from "./AuthContext";
+
+const PrivateRoute = ({ children }) => {
+    const { isAuthenticated, loading } = useAuth();
+
+    // 로딩 중일 때 아무것도 렌더링하지 않음
+    if (loading) {
+        return <div>Loading...</div>;
+    }
+
+    // 인증되지 않은 경우 로그인 페이지로 리다이렉트
+    return isAuthenticated ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/ssafynity-f/src/pages/Login.js
+++ b/ssafynity-f/src/pages/Login.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import axiosInstance from "../api/axiosInstance"; // 설정한 Axios 인스턴스 불러오기
+import { useAuth } from '../components/AuthContext';
 import { useNavigate } from "react-router-dom"; // useNavigate import
 import "../styles/Login.css"; // 스타일 파일
 
@@ -7,6 +8,7 @@ function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [userData, setUserData] = useState(""); // 로그인 결과 메시지 저장
+  const { login } = useAuth(); // useAuth 훅에서 login 메서드 가져오기
   const navigate = useNavigate(); // useNavigate 생성
 
   const handleSubmit = async (e) => {
@@ -25,6 +27,9 @@ function Login() {
 
         // JWT 토큰을 localStorage에 저장
         localStorage.setItem("jwtToken", jwtToken);
+
+        // 인증 상태를 업데이트 (AuthContext의 login 메서드 호출)
+        login();
 
 
         // 상태로 다른 페이지로 이동

--- a/ssafynity-f/src/pages/SignUp.js
+++ b/ssafynity-f/src/pages/SignUp.js
@@ -3,7 +3,7 @@ import axiosInstance from "../api/axiosInstance"; // 설정한 Axios 인스턴�
 import { useNavigate } from "react-router-dom"; // useNavigate import
 import "../styles/Login.css"; // 스타일 파일
 
-function SignUp() {
+function Signup() {
   const [name, setName] = useState("");
   const [company, setCompany] = useState("");
   const [email, setEmail] = useState("");
@@ -90,4 +90,4 @@ function SignUp() {
       );
 }
 
-export default SignUp;
+export default Signup;


### PR DESCRIPTION
FEAT:[BE] jwt토큰 검증API 생성, [FE]페이지 요청마다 jwt토큰 유효성 검사 실행 로직 구현
1. [BE] AuthController에 jwt토큰 검증API 구현했습니다.
2. [FE] components -> AuthContext.js, PrivateRoute.js 생성
3. AuthContext.js, PrivateRoute.js를 통해 페이지 요청마다 jwt토큰 유효성 검사 실행 로직 구현