### PR TITLE
FEAT:S3를 로컬에서 테스트할수있는 MinIO 적용 및 파일 저장 시스템 구축

### DIFF
--- a/SSAFYnity_B/build.gradle
+++ b/SSAFYnity_B/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 처리 라이브러리
+	// minio
+	implementation 'io.minio:minio:8.3.4'
 }
 
 tasks.named('test') {

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/attendence/service/AttendanceServiceImpl.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/attendence/service/AttendanceServiceImpl.java
@@ -13,7 +13,6 @@ import com.ssafynity_b.global.exception.CheckOutException;
 import com.ssafynity_b.global.jwt.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/controller/MemberController.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/controller/MemberController.java
@@ -2,14 +2,20 @@ package com.ssafynity_b.domain.member.controller;
 
 import com.ssafynity_b.domain.member.dto.*;
 import com.ssafynity_b.domain.member.service.MemberService;
+import com.ssafynity_b.global.fileupload.minio.service.MinIoUploadService;
+import com.ssafynity_b.global.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 
 @RestController
@@ -19,6 +25,7 @@ import java.util.List;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MinIoUploadService minioUploadService;
 
     @Operation(summary = "회원 생성")
     @PostMapping
@@ -76,5 +83,19 @@ public class MemberController {
     public ResponseEntity<?> getMemberByName(@PathVariable String keyword) throws IOException {
         List<GetMemberDto> memberList = memberService.searchMemberByName(keyword);
         return new ResponseEntity<List<GetMemberDto>>(memberList, HttpStatus.OK);
+    }
+
+    @Operation(summary = "프로필이미지 저장(MinIO,Multipartfile방식)")
+    @PostMapping(value = "/upload/profileImage", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public String saveProfileImageByMinIO(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestPart("file")MultipartFile file){
+        try(InputStream inputStream = file.getInputStream()){
+            String fileName = file.getOriginalFilename();
+            long contentLength = file.getSize();
+
+            minioUploadService.uploadFileToMinio(fileName, inputStream, contentLength);
+            return "업로드 완료";
+        } catch(IOException e){
+            return "업로드 실패 : " + e.getMessage();
+        }
     }
 }

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/config/minioConfig.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/config/minioConfig.java
@@ -1,0 +1,28 @@
+package com.ssafynity_b.global.config;
+
+import io.minio.MinioClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class minioConfig {
+
+    @Value("${minio.url}")
+    private String url;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    //Minio 클라이언트 설정
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(url)
+                .credentials(accessKey,secretKey)
+                .build();
+    }
+}

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/MinIoUploadService.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/MinIoUploadService.java
@@ -1,0 +1,7 @@
+package com.ssafynity_b.global.fileupload.minio.service;
+
+import java.io.InputStream;
+
+public interface MinIoUploadService {
+    public void uploadFileToMinio(String fileName, InputStream inputStream, long contentLength);
+}

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/impl/MinIoUploadServiceImpl.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/impl/MinIoUploadServiceImpl.java
@@ -1,0 +1,55 @@
+package com.ssafynity_b.global.fileupload.minio.service.impl;
+
+import com.ssafynity_b.global.fileupload.minio.service.MinIoUploadService;
+import io.minio.MinioClient;
+import io.minio.PutObjectArgs;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class MinIoUploadServiceImpl implements MinIoUploadService {
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.bucket-name}")
+    String BUCKET_NAME;
+
+    @Value("${minio.directory-path}")
+    String DIRECTORY_PATH;
+
+    @Override
+    public void uploadFileToMinio(String fileName, InputStream inputStream, long contentLength) {
+        try {
+            PutObjectArgs putObjectArgs = PutObjectArgs.builder()
+                    .bucket(BUCKET_NAME)
+                    .object(DIRECTORY_PATH + UUID.randomUUID() + fileName)
+                    .stream(inputStream, contentLength, -1)
+                    .contentType(getContentType(fileName))
+                    .build();
+
+            minioClient.putObject(putObjectArgs);
+        }catch (Exception e) {
+            System.err.println("Other errors: " + e.getMessage());
+        }
+    }
+
+    private String getContentType(String fileName){
+        Path path = Paths.get(fileName);
+        String contentType = null;
+        try{
+            contentType = Files.probeContentType(path);
+        } catch(IOException e){
+            System.out.println("Error determining content type : "+ e.getMessage());
+        }
+        return contentType;
+    }
+}

--- a/SSAFYnity_B/src/main/resources/application.yml
+++ b/SSAFYnity_B/src/main/resources/application.yml
@@ -7,3 +7,4 @@ spring:
 
 server:
   port: 8080
+


### PR DESCRIPTION
FEAT:S3를 로컬에서 테스트할수있는 MinIO 적용 및 파일 저장 시스템 구축
1. 로컬에서 MinIO에 MultipartFile방식으로 파일저장 API를 만들었습니다.
2. Stream방식이 더 효율적일 것이라 예상됩니다.
3. 이후 Stream방식으로 다시 제작하고 MultipartFile방식과 Stream방식 사이에 무엇이 더 효율적인지 성능테스트를 진행해보겠습니다.