### PR TITLE
FEAT: 프로필이미지 저장할때 users/memberId/profile 경로에 저장하도록 변경

### DIFF
--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/controller/MemberController.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/domain/member/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
     private final MinIoUploadService minioUploadService;
 
     @Operation(summary = "회원 생성")
-    @PostMapping
+    @PostMapping("/signup")
     public ResponseEntity<?> createMember(@RequestBody CreateMemberDto memberDto){
         Long memberId = memberService.createMember(memberDto);
         return new ResponseEntity<Long>(memberId, HttpStatus.OK);
@@ -92,7 +92,7 @@ public class MemberController {
             String fileName = file.getOriginalFilename();
             long contentLength = file.getSize();
 
-            minioUploadService.uploadFileToMinio(fileName, inputStream, contentLength);
+            minioUploadService.uploadFileToMinio(userDetails, fileName, inputStream, contentLength);
             return "업로드 완료";
         } catch(IOException e){
             return "업로드 실패 : " + e.getMessage();

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/MinIoUploadService.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/MinIoUploadService.java
@@ -1,7 +1,9 @@
 package com.ssafynity_b.global.fileupload.minio.service;
 
+import com.ssafynity_b.global.jwt.CustomUserDetails;
+
 import java.io.InputStream;
 
 public interface MinIoUploadService {
-    public void uploadFileToMinio(String fileName, InputStream inputStream, long contentLength);
+    public void uploadFileToMinio(CustomUserDetails userDetails, String fileName, InputStream inputStream, long contentLength);
 }

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/impl/MinIoUploadServiceImpl.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/fileupload/minio/service/impl/MinIoUploadServiceImpl.java
@@ -1,6 +1,7 @@
 package com.ssafynity_b.global.fileupload.minio.service.impl;
 
 import com.ssafynity_b.global.fileupload.minio.service.MinIoUploadService;
+import com.ssafynity_b.global.jwt.CustomUserDetails;
 import io.minio.MinioClient;
 import io.minio.PutObjectArgs;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @Service
@@ -27,21 +27,30 @@ public class MinIoUploadServiceImpl implements MinIoUploadService {
     String DIRECTORY_PATH;
 
     @Override
-    public void uploadFileToMinio(String fileName, InputStream inputStream, long contentLength) {
+    public void uploadFileToMinio(CustomUserDetails userDetails, String fileName, InputStream inputStream, long contentLength) {
+        //멤버 이름
+        Long memberId = userDetails.getMember().getId();
+
         try {
+            //MinIO버킷에 저장할 객체 생성
+            //경로(-> user/멤버 이름/fileName)에 이미지 저장
             PutObjectArgs putObjectArgs = PutObjectArgs.builder()
                     .bucket(BUCKET_NAME)
-                    .object(DIRECTORY_PATH + UUID.randomUUID() + fileName)
+                    .object(DIRECTORY_PATH + memberId + "/profile")
                     .stream(inputStream, contentLength, -1)
                     .contentType(getContentType(fileName))
                     .build();
 
+            //MinIO버킷에 객체 저장
             minioClient.putObject(putObjectArgs);
+
+        //오류 발생시 예외처리
         }catch (Exception e) {
             System.err.println("Other errors: " + e.getMessage());
         }
     }
 
+    //파일 타입 추출(ex.jpg,webp,png,jpeg...)
     private String getContentType(String fileName){
         Path path = Paths.get(fileName);
         String contentType = null;

--- a/SSAFYnity_B/src/main/java/com/ssafynity_b/global/jwt/JwtAuthenticationFilter.java
+++ b/SSAFYnity_B/src/main/java/com/ssafynity_b/global/jwt/JwtAuthenticationFilter.java
@@ -37,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String requestPath = request.getRequestURI();
 
         // Swagger 관련 경로, 회원가입,로그인 경로는 필터링하지 않음
-        if (requestPath.startsWith("/swagger-ui") || requestPath.startsWith("/v3/api-docs") || requestPath.startsWith("/api/auth/login") || requestPath.startsWith("/api/member") && "POST".equalsIgnoreCase(request.getMethod())) {
+        if (requestPath.startsWith("/swagger-ui") || requestPath.startsWith("/v3/api-docs") || requestPath.startsWith("/api/auth/login") || requestPath.startsWith("/api/member/signup")) {
             filterChain.doFilter(request, response); // 다음 필터로 이동
             return;
         }


### PR DESCRIPTION
FEAT: 프로필이미지 저장할때 users/memberId/profile 경로에 저장하도록 변경
1. 멤버가 프로필 이미지 변경을 하게되면 기존 이미지가 새로운 이미지로 덮어씌워집니다.
2. 따라서 멤버는 한명당 하나의 프로필 이미지만 저장할수있게하여, MinIO서버의 비용을 줄였습니다.